### PR TITLE
Make navbar a component

### DIFF
--- a/app/src/components/Heading.tsx
+++ b/app/src/components/Heading.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import {
+    IonBackButton,
+    IonButton,
+    IonButtons,
+    IonContent,
+    IonHeader,
+    IonIcon,
+    IonPage,
+    IonTitle,
+    IonToolbar,
+} from "@ionic/react";
+import { ellipsisHorizontal, ellipsisVertical, personCircle, search } from "ionicons/icons";
+
+interface HeadingProps {
+    title: string;
+}
+
+const Heading: React.FC<HeadingProps> = ({ title }) => {
+    return (
+        <IonHeader>
+            <IonToolbar color="dark">
+                <IonButtons slot="start">
+                    <IonBackButton />
+                </IonButtons>
+                <IonButtons slot="secondary">
+                    <IonButton>
+                        <IonIcon slot="icon-only" icon={personCircle} />
+                    </IonButton>
+                </IonButtons>
+                <IonTitle className="text-center text-2xl font-heading">{title ? title : "Industry 4.0"}</IonTitle>
+            </IonToolbar>
+        </IonHeader>
+    );
+};
+
+export default Heading;

--- a/app/src/pages/Page.tsx
+++ b/app/src/pages/Page.tsx
@@ -16,7 +16,7 @@ import "./Page.css";
 import { from, useQuery } from "@apollo/client";
 import { GetUserById } from "../types/GetUserById";
 import { GET_USER_BY_ID } from "../common/graphql/queries/users";
-import { ellipsisHorizontal, ellipsisVertical, personCircle, search } from "ionicons/icons";
+import Heading from "../components/Heading";
 import LineGraph from "../components/LineGraph";
 
 const Page: React.FC = () => {
@@ -44,16 +44,7 @@ const Page: React.FC = () => {
     return (
         <IonPage>
             <link href="https://fonts.googleapis.com/css?family=Share Tech Mono" rel="stylesheet"></link>
-            <IonHeader>
-                <IonToolbar color="dark">
-                    <IonButtons slot="secondary">
-                        <IonButton>
-                            <IonIcon slot="icon-only" icon={personCircle} />
-                        </IonButton>
-                    </IonButtons>
-                    <IonTitle className="text-center text-2xl font-heading">Industry 4.0</IonTitle>
-                </IonToolbar>
-            </IonHeader>
+            <Heading title="Industry 4.0" />
 
             <IonContent color="new">
                 <div className="statusBar h-16">


### PR DESCRIPTION
## GitHub Issue Solved:

n/a

## Current behaviour
navbar is part of the code in Page.tsx
<!--Please describe the current behaviour-->

## Changed behaviour
Navbar is now its own component, so it can be used in any new pages
It also takes in a parameter; title, which can be used to change the title of the navbar/header.  
A back button has been added, which can be seen once other pages start getting added in and you switch from one page to another
<!--Please describe the behaviour after the PR has been merged.  Please be explicit in what the PR is expected to do-->

## PR checklist

Remember to check the following

 - [x] Tag specific people to review your PR
 - [x] Update the ReadMe with any new run instructions
 - [x] Closes the associated issue (if applicable)

## Notes

<!--You may add screenshots or other information if you think it's relevant-->

### Demo
If you run the project, it should look the same visually, the only change should be refactoring
<!--If applicable, give a demo to help people understand the PR change-->

### Run instructions
n/a
<!--Any instructions specific to the code that was added and how to observe the effects-->
