### PR TITLE
Download Data for particular sensor

### DIFF
--- a/api/functions/src/downloads/handlers.ts
+++ b/api/functions/src/downloads/handlers.ts
@@ -4,6 +4,26 @@ export const generateSensorDataCSV = async (
   machineId: string,
   sensorId: string
 ): Promise<string> => {
-  // const sampleChunks = await MachineStore.getSampleChunks(machineId, sensorId);
-  return 'signal1\n0.8';
+  const sampleChunks = (await MachineStore.getSampleChunks(
+    machineId,
+    sensorId
+  )) as {
+    samples: {
+      timestamp: FirebaseFirestore.Timestamp;
+      value: number;
+    }[];
+  }[];
+
+  let fileString = 'timestamp, value\n';
+
+  // iterate over every sample of every sampleChunk and add it to the CSV as a row
+  sampleChunks.forEach((value) => {
+    value.samples.forEach((value) => {
+      fileString =
+        fileString +
+        `${value.timestamp.toDate().toISOString()}, ${value.value}\n`;
+    });
+  });
+
+  return fileString;
 };

--- a/api/functions/src/downloads/handlers.ts
+++ b/api/functions/src/downloads/handlers.ts
@@ -1,3 +1,9 @@
-export const generateSensorDataCSV = (sensorId: string): string => {
+import { MachineStore } from '../graphql/MachineStore';
+
+export const generateSensorDataCSV = async (
+  machineId: string,
+  sensorId: string
+): Promise<string> => {
+  // const sampleChunks = await MachineStore.getSampleChunks(machineId, sensorId);
   return 'signal1\n0.8';
 };

--- a/api/functions/src/downloads/handlers.ts
+++ b/api/functions/src/downloads/handlers.ts
@@ -1,0 +1,3 @@
+export const generateSensorDataCSV = (sensorId: string): string => {
+  return 'signal1\n0.8';
+};

--- a/api/functions/src/downloads/server.ts
+++ b/api/functions/src/downloads/server.ts
@@ -7,18 +7,24 @@ export function ConstructFileDownloadServer() {
   app.use(cors());
   app.options('*');
 
-  app.get('machine/:machineId/sensor/:sensorId', (req, res) => {
+  app.get('/machine/:machineId/sensor/:sensorId', async (req, res) => {
     if (!req.params.sensorId || !req.params.machineId) {
       res.status(400).send('Bad Request');
       return;
     }
 
-    const data = generateSensorDataCSV(
+    const data = await generateSensorDataCSV(
       req.params.machineId,
       req.params.sensorId
     );
 
-    res.set('Content-Type', 'text/csv').send(data);
+    res
+      .set({
+        'Content-Type': 'text/csv',
+        'Content-Disposition': 'attachment; filename="sensorData.csv"',
+      })
+      .send(data);
   });
+
   return app;
 }

--- a/api/functions/src/downloads/server.ts
+++ b/api/functions/src/downloads/server.ts
@@ -7,13 +7,16 @@ export function ConstructFileDownloadServer() {
   app.use(cors());
   app.options('*');
 
-  app.get('/sensor/:sensorId', (req, res) => {
-    if (!req.params.sensorId) {
+  app.get('machine/:machineId/sensor/:sensorId', (req, res) => {
+    if (!req.params.sensorId || !req.params.machineId) {
       res.status(400).send('Bad Request');
       return;
     }
 
-    const data = generateSensorDataCSV(req.params.sensorId);
+    const data = generateSensorDataCSV(
+      req.params.machineId,
+      req.params.sensorId
+    );
 
     res.set('Content-Type', 'text/csv').send(data);
   });

--- a/api/functions/src/downloads/server.ts
+++ b/api/functions/src/downloads/server.ts
@@ -1,0 +1,21 @@
+import cors from 'cors';
+import express from 'express';
+import { generateSensorDataCSV } from './handlers';
+
+export function ConstructFileDownloadServer() {
+  const app = express();
+  app.use(cors());
+  app.options('*');
+
+  app.get('/sensor/:sensorId', (req, res) => {
+    if (!req.params.sensorId) {
+      res.status(400).send('Bad Request');
+      return;
+    }
+
+    const data = generateSensorDataCSV(req.params.sensorId);
+
+    res.set('Content-Type', 'text/csv').send(data);
+  });
+  return app;
+}

--- a/api/functions/src/generated/graphql.ts
+++ b/api/functions/src/generated/graphql.ts
@@ -1,8 +1,15 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from 'graphql';
 import { GraphQLContext } from '../../src/types';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
-export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+export type RequireFields<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X];
+} &
+  { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -12,7 +19,6 @@ export type Scalars = {
   Float: number;
   Date: any;
 };
-
 
 export type Machine = {
   __typename?: 'Machine';
@@ -52,17 +58,14 @@ export type Mutation = {
   createSensor?: Maybe<SensorCreationResponse>;
 };
 
-
 export type MutationUpdateUserArgs = {
   id: Scalars['ID'];
 };
-
 
 export type MutationUpdateMachineArgs = {
   id: Scalars['ID'];
   input?: Maybe<MachineUpdateInput>;
 };
-
 
 export type MutationUpdateSensorArgs = {
   id: Scalars['ID'];
@@ -70,11 +73,9 @@ export type MutationUpdateSensorArgs = {
   input?: Maybe<SensorUpdateInput>;
 };
 
-
 export type MutationCreateMachineArgs = {
   name: Scalars['String'];
 };
-
 
 export type MutationCreateSensorArgs = {
   input?: Maybe<SensorInput>;
@@ -94,16 +95,13 @@ export type Query = {
   sensor?: Maybe<Sensor>;
 };
 
-
 export type QueryUserArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryMachineArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QuerySensorArgs = {
   machineId: Scalars['ID'];
@@ -164,12 +162,12 @@ export type SensorUpdateInput = {
 export enum Status {
   Nominal = 'Nominal',
   Moderate = 'Moderate',
-  Critical = 'Critical'
+  Critical = 'Critical',
 }
 
 export enum Unit {
   Mps2 = 'MPS2',
-  Mps2Rms = 'MPS2_RMS'
+  Mps2Rms = 'MPS2_RMS',
 }
 
 export type User = {
@@ -192,7 +190,6 @@ export type ResolversObject<TObject> = WithIndex<TObject>;
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
@@ -202,7 +199,9 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
   selectionSet: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
@@ -228,9 +227,25 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -238,12 +253,26 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -252,11 +281,19 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (
+  obj: T,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -316,14 +353,22 @@ export type ResolversParentTypes = ResolversObject<{
   UserUpdatedResponse: UserUpdatedResponse;
 }>;
 
-export interface DateScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
+export interface DateScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
   name: 'Date';
 }
 
-export type MachineResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Machine'] = ResolversParentTypes['Machine']> = ResolversObject<{
+export type MachineResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['Machine'] = ResolversParentTypes['Machine']
+> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  healthStatus?: Resolver<Maybe<ResolversTypes['Status']>, ParentType, ContextType>;
+  healthStatus?: Resolver<
+    Maybe<ResolversTypes['Status']>,
+    ParentType,
+    ContextType
+  >;
   sensors?: Resolver<Array<ResolversTypes['Sensor']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
@@ -359,37 +404,75 @@ export type MutationResponseResolvers<ContextType = GraphQLContext, ParentType e
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
-export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
-  machines?: Resolver<Array<ResolversTypes['Machine']>, ParentType, ContextType>;
-  machine?: Resolver<Maybe<ResolversTypes['Machine']>, ParentType, ContextType, RequireFields<QueryMachineArgs, 'id'>>;
-  sensor?: Resolver<Maybe<ResolversTypes['Sensor']>, ParentType, ContextType, RequireFields<QuerySensorArgs, 'machineId' | 'id'>>;
+export type QueryResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = ResolversObject<{
+  user?: Resolver<
+    Maybe<ResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryUserArgs, 'id'>
+  >;
+  machines?: Resolver<
+    Array<ResolversTypes['Machine']>,
+    ParentType,
+    ContextType
+  >;
+  machine?: Resolver<
+    Maybe<ResolversTypes['Machine']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryMachineArgs, 'id'>
+  >;
+  sensor?: Resolver<
+    Maybe<ResolversTypes['Sensor']>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySensorArgs, 'machineId' | 'id'>
+  >;
 }>;
 
-export type SampleResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Sample'] = ResolversParentTypes['Sample']> = ResolversObject<{
+export type SampleResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['Sample'] = ResolversParentTypes['Sample']
+> = ResolversObject<{
   timestamp?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type SampleChunkResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['SampleChunk'] = ResolversParentTypes['SampleChunk']> = ResolversObject<{
+export type SampleChunkResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['SampleChunk'] = ResolversParentTypes['SampleChunk']
+> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   samples?: Resolver<Array<ResolversTypes['Sample']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type SensorResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Sensor'] = ResolversParentTypes['Sensor']> = ResolversObject<{
+export type SensorResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['Sensor'] = ResolversParentTypes['Sensor']
+> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   machineId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   healthStatus?: Resolver<Maybe<ResolversTypes['Status']>, ParentType, ContextType>;
   threshold?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   unit?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  sampleChunks?: Resolver<Array<ResolversTypes['SampleChunk']>, ParentType, ContextType>;
+  sampleChunks?: Resolver<
+    Array<ResolversTypes['SampleChunk']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type SensorCreationResponseResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['SensorCreationResponse'] = ResolversParentTypes['SensorCreationResponse']> = ResolversObject<{
+export type SensorCreationResponseResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['SensorCreationResponse'] = ResolversParentTypes['SensorCreationResponse']
+> = ResolversObject<{
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -413,7 +496,10 @@ export type UserResolvers<ContextType = GraphQLContext, ParentType extends Resol
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type UserUpdatedResponseResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['UserUpdatedResponse'] = ResolversParentTypes['UserUpdatedResponse']> = ResolversObject<{
+export type UserUpdatedResponseResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['UserUpdatedResponse'] = ResolversParentTypes['UserUpdatedResponse']
+> = ResolversObject<{
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -436,7 +522,6 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   User?: UserResolvers<ContextType>;
   UserUpdatedResponse?: UserUpdatedResponseResolvers<ContextType>;
 }>;
-
 
 /**
  * @deprecated

--- a/api/functions/src/graphql/resolvers/mutation.ts
+++ b/api/functions/src/graphql/resolvers/mutation.ts
@@ -69,7 +69,7 @@ export const mutationResolvers: MutationResolvers = {
       code: 'sensor_create/success',
       success: true,
       message: 'Sensor Created Successfully.',
-      sensor: newSensor
+      sensor: newSensor,
     };
 
     return resp;

--- a/api/functions/src/index.ts
+++ b/api/functions/src/index.ts
@@ -1,7 +1,13 @@
 import * as functions from 'firebase-functions';
-import { ConstructGraphQLServer } from './graphql/server';
+import {
+  ConstructFileDownloadServer,
+  ConstructGraphQLServer,
+} from './graphql/server';
 
 const USCentralRegion = functions.SUPPORTED_REGIONS[0];
 exports.graph = functions
   .region(USCentralRegion)
   .https.onRequest(ConstructGraphQLServer());
+exports.download = functions
+  .region(USCentralRegion)
+  .https.onRequest(ConstructFileDownloadServer());

--- a/api/functions/src/index.ts
+++ b/api/functions/src/index.ts
@@ -1,8 +1,6 @@
 import * as functions from 'firebase-functions';
-import {
-  ConstructFileDownloadServer,
-  ConstructGraphQLServer,
-} from './graphql/server';
+import { ConstructGraphQLServer } from './graphql/server';
+import { ConstructFileDownloadServer } from './downloads/server';
 
 const USCentralRegion = functions.SUPPORTED_REGIONS[0];
 exports.graph = functions

--- a/app/src/pages/Sensor.tsx
+++ b/app/src/pages/Sensor.tsx
@@ -20,6 +20,7 @@ import LineGraph from "../components/LineGraph";
 import { GET_SENSOR_BY_ID } from "../common/graphql/queries/sensors";
 // import { QuerySensorArgs } from "../types/types";
 // import { Scalars } from "../types/types";
+import { getLinkForSensor } from "../services/download/download";
 
 const Sensor: React.FC = () => {
     // const { machineId } = useParams<{ machineId: Scalars["ID"] }>();
@@ -61,7 +62,13 @@ const Sensor: React.FC = () => {
                     <LineGraph title="Sensor Values" redThreshold={600} yellowThreshold={400} data={data} />
                 </div>
                 <div className="download text-center">
-                    <IonButton shape="round" color="light" className="responsive-width text-lg normal-case">
+                    <IonButton
+                        shape="round"
+                        color="light"
+                        className="responsive-width text-lg normal-case"
+                        download="sensor data"
+                        href={getLinkForSensor("AD1AECvCTuMi29JF0WTC", "cUq2QVLOQCqKil6eq0El")}
+                    >
                         Download
                     </IonButton>
                 </div>

--- a/app/src/pages/Sensor.tsx
+++ b/app/src/pages/Sensor.tsx
@@ -25,11 +25,11 @@ import { getLinkForSensor } from "../services/download/download";
 const Sensor: React.FC = () => {
     // const { machineId } = useParams<{ machineId: Scalars["ID"] }>();
     // const { id } = useParams<{ id: Scalars["ID"] }>();
-    const { machineId } = useParams<{ machineId: string }>();
+    const { machineid } = useParams<{ machineid: string }>();
     const { id } = useParams<{ id: string }>();
     // const tmp: QuerySensorArgs = { id: id, machineId: machineId };
     const sensor_data = useQuery<getSensorById>(GET_SENSOR_BY_ID, {
-        variables: { machineId: machineId, id: id },
+        variables: { machineId: machineid, id: id },
     });
     console.log(sensor_data);
     const data = [
@@ -67,7 +67,7 @@ const Sensor: React.FC = () => {
                         color="light"
                         className="responsive-width text-lg normal-case"
                         download="sensor data"
-                        href={getLinkForSensor("AD1AECvCTuMi29JF0WTC", "cUq2QVLOQCqKil6eq0El")}
+                        href={getLinkForSensor(machineid || "", id || "")}
                     >
                         Download
                     </IonButton>

--- a/app/src/services/download/download.ts
+++ b/app/src/services/download/download.ts
@@ -1,0 +1,7 @@
+import urljoin from "url-join";
+
+const baseDownloadURI = urljoin(process.env.REACT_APP_ENDPOINT_URL || "", "download");
+
+export function getLinkForSensor(machineId: string, sensorId: string): string {
+    return urljoin(baseDownloadURI, "machine", machineId, "sensor", sensorId);
+}


### PR DESCRIPTION
## GitHub Issue Solved:

closes #15 

## Current behaviour

Download button does nothing

## Changed behaviour

Button now triggers a file download with all the data from the sensor's history

## PR checklist

Remember to check the following

 - [x] Tag specific people to review your PR
 - [x] Update the ReadMe with any new run instructions (N/A)
 - [x] Closes the associated issue (if applicable)

## Notes

<!--You may add screenshots or other information if you think it's relevant-->

There is now an additional firebase function responsible for serving file downloads from sensor data.
The frontend builds a link to the HTTP endpoint for that function - the button now has that link as it's destination. So when the user clicks the download button, their browser will initiate a file download.

### Run instructions

<!--Any instructions specific to the code that was added and how to observe the effects-->

Like normal, make sure you have run `npm install` in the relevant places. However, note that this particular PR adds no npm packages. Obviously you should also have done `firebase use industry4-uoa` inside `api/functions`. 

To run, simply `npm start` from the project root. Then visit http://localhost:3000/machine/AD1AECvCTuMi29JF0WTC
Click on DummySensorTwo, then click Download. Your browser should download a file called `sensorData.csv`
