### PR TITLE
Fixed sensor page overwrites

### DIFF
--- a/app/src/pages/Sensors.tsx
+++ b/app/src/pages/Sensors.tsx
@@ -48,34 +48,30 @@ const Sensors: React.FC = () => {
             <IonContent color="new">
                 {machine_data.data?.machine ? (
                     <>
-                        {sensors ? (
-                            sensors
-                                .slice()
-                                .sort((a, b) => stringCompare(a.healthStatus, b.healthStatus))
-                                .map((sensor) => (
-                                    <div className="responsive-width grid grid-cols-1 m-auto p-3" key={sensor.id}>
-                                        <Link to={`/machine/${id}/sensor/${sensor.id}`}>
-                                            <div className="darken-on-hover">
-                                                <HealthContainer
-                                                    name={sensor.name}
-                                                    value={
-                                                        sensor.sampleChunks.slice(-1)[0]?.samples.slice(-1)[0]?.value
-                                                    }
-                                                    health={sensor.healthStatus}
-                                                />
-                                            </div>
-                                        </Link>
-                                    </div>
-                                ))
-                        ) : (
-                            <Error404 message="There are no sensors for this machine" />
-                        )}
-                        <div className="download text-center">
-                            <IonFab vertical="bottom" horizontal="center" slot="fixed">
-                                <IonFabButton color="light">
-                                    <IonIcon icon={add} />
-                                </IonFabButton>
-                            </IonFab>
+                        <div className="pb-20">
+                            {sensors ? (
+                                sensors
+                                    .slice()
+                                    .sort((a, b) => stringCompare(a.healthStatus, b.healthStatus))
+                                    .map((sensor) => (
+                                        <div className="responsive-width grid grid-cols-1 m-auto p-3" key={sensor.id}>
+                                            <Link to={`/machine/${id}/sensor/${sensor.id}`}>
+                                                <div className="darken-on-hover">
+                                                    <HealthContainer
+                                                        name={sensor.name}
+                                                        value={
+                                                            sensor.sampleChunks.slice(-1)[0]?.samples.slice(-1)[0]
+                                                                ?.value
+                                                        }
+                                                        health={sensor.healthStatus}
+                                                    />
+                                                </div>
+                                            </Link>
+                                        </div>
+                                    ))
+                            ) : (
+                                <Error404 message="There are no sensors for this machine" />
+                            )}
                         </div>
                         <IonFab vertical="bottom" horizontal="center" slot="fixed">
                             <IonFabButton color="light">


### PR DESCRIPTION
## GitHub Issue Solved:

N/A

## Current behaviour

There were overwrites/duplicate code on the sensors page after merging the previous pull request
- 2 Add Sensor buttons, one not floating on top
- No gap at bottom of page between bottom sensor and floating add sensor button

## Changed behaviour

- 1 Add sensor button, floating
- Gap between last sensor and add sensor button

## PR checklist

Remember to check the following

 - [x] Tag specific people to review your PR
 - [ ] Update the ReadMe with any new run instructions
 - [ ] Closes the associated issue (if applicable)
 - [ ] Updated kanban board

## Notes
N/A

### Demo
- Run
- Go to the TestingPR machine
- Scroll up & down, see that there is only one button
- Scroll down to the bottom, see that there is a gap between the last sensor and the add button

### Run instructions

- Run as normal
