### PR TITLE
Machine image upload

### DIFF
--- a/api/functions/src/generated/graphql.ts
+++ b/api/functions/src/generated/graphql.ts
@@ -1,15 +1,8 @@
-import {
-  GraphQLResolveInfo,
-  GraphQLScalarType,
-  GraphQLScalarTypeConfig,
-} from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import { GraphQLContext } from '../../src/types';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
-export type RequireFields<T, K extends keyof T> = {
-  [X in Exclude<keyof T, K>]?: T[X];
-} &
-  { [P in K]-?: NonNullable<T[P]> };
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -20,11 +13,13 @@ export type Scalars = {
   Date: any;
 };
 
+
 export type Machine = {
   __typename?: 'Machine';
   id: Scalars['ID'];
   name: Scalars['String'];
   healthStatus?: Maybe<Status>;
+  image: Scalars['String'];
   sensors: Array<Sensor>;
 };
 
@@ -47,6 +42,7 @@ export type MachineUpdatedResponse = MutationResponse & {
 export type MachineUpdateInput = {
   name?: Maybe<Scalars['String']>;
   healthStatus?: Maybe<Status>;
+  image?: Maybe<Scalars['String']>;
 };
 
 export type Mutation = {
@@ -58,14 +54,17 @@ export type Mutation = {
   createSensor?: Maybe<SensorCreationResponse>;
 };
 
+
 export type MutationUpdateUserArgs = {
   id: Scalars['ID'];
 };
+
 
 export type MutationUpdateMachineArgs = {
   id: Scalars['ID'];
   input?: Maybe<MachineUpdateInput>;
 };
+
 
 export type MutationUpdateSensorArgs = {
   id: Scalars['ID'];
@@ -73,9 +72,12 @@ export type MutationUpdateSensorArgs = {
   input?: Maybe<SensorUpdateInput>;
 };
 
+
 export type MutationCreateMachineArgs = {
   name: Scalars['String'];
+  image: Scalars['String'];
 };
+
 
 export type MutationCreateSensorArgs = {
   input?: Maybe<SensorInput>;
@@ -101,13 +103,16 @@ export type Query = {
   sensor?: Maybe<Sensor>;
 };
 
+
 export type QueryUserArgs = {
   id: Scalars['ID'];
 };
 
+
 export type QueryMachineArgs = {
   id: Scalars['ID'];
 };
+
 
 export type QuerySensorArgs = {
   machineId: Scalars['ID'];
@@ -170,12 +175,12 @@ export type SensorUpdateInput = {
 export enum Status {
   Nominal = 'Nominal',
   Moderate = 'Moderate',
-  Critical = 'Critical',
+  Critical = 'Critical'
 }
 
 export enum Unit {
   Mps2 = 'MPS2',
-  Mps2Rms = 'MPS2_RMS',
+  Mps2Rms = 'MPS2_RMS'
 }
 
 export type User = {
@@ -198,6 +203,7 @@ export type ResolversObject<TObject> = WithIndex<TObject>;
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
+
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
@@ -207,9 +213,7 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
   selectionSet: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type StitchingResolver<TResult, TParent, TContext, TArgs> =
-  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
-  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
@@ -235,25 +239,9 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> {
-  subscribe: SubscriptionSubscribeFn<
-    { [key in TKey]: TResult },
-    TParent,
-    TContext,
-    TArgs
-  >;
-  resolve?: SubscriptionResolveFn<
-    TResult,
-    { [key in TKey]: TResult },
-    TContext,
-    TArgs
-  >;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -261,26 +249,12 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> =
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<
-  TResult,
-  TKey extends string,
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> =
-  | ((
-      ...args: any[]
-    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -289,19 +263,11 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}> = (
-  obj: T,
-  info: GraphQLResolveInfo
-) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<
-  TResult = {},
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> = (
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -362,22 +328,15 @@ export type ResolversParentTypes = ResolversObject<{
   UserUpdatedResponse: UserUpdatedResponse;
 }>;
 
-export interface DateScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
+export interface DateScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
   name: 'Date';
 }
 
-export type MachineResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes['Machine'] = ResolversParentTypes['Machine']
-> = ResolversObject<{
+export type MachineResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Machine'] = ResolversParentTypes['Machine']> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  healthStatus?: Resolver<
-    Maybe<ResolversTypes['Status']>,
-    ParentType,
-    ContextType
-  >;
+  healthStatus?: Resolver<Maybe<ResolversTypes['Status']>, ParentType, ContextType>;
+  image?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   sensors?: Resolver<Array<ResolversTypes['Sensor']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
@@ -402,7 +361,7 @@ export type MutationResolvers<ContextType = GraphQLContext, ParentType extends R
   updateUser?: Resolver<Maybe<ResolversTypes['MutationResponse']>, ParentType, ContextType, RequireFields<MutationUpdateUserArgs, 'id'>>;
   updateMachine?: Resolver<Maybe<ResolversTypes['MachineUpdatedResponse']>, ParentType, ContextType, RequireFields<MutationUpdateMachineArgs, 'id'>>;
   updateSensor?: Resolver<Maybe<ResolversTypes['SensorUpdatedResponse']>, ParentType, ContextType, RequireFields<MutationUpdateSensorArgs, 'id' | 'machineID'>>;
-  createMachine?: Resolver<Maybe<ResolversTypes['MachineCreationResponse']>, ParentType, ContextType, RequireFields<MutationCreateMachineArgs, 'name'>>;
+  createMachine?: Resolver<Maybe<ResolversTypes['MachineCreationResponse']>, ParentType, ContextType, RequireFields<MutationCreateMachineArgs, 'name' | 'image'>>;
   createSensor?: Resolver<Maybe<ResolversTypes['SensorCreationResponse']>, ParentType, ContextType, RequireFields<MutationCreateSensorArgs, never>>;
 }>;
 
@@ -413,57 +372,26 @@ export type MutationResponseResolvers<ContextType = GraphQLContext, ParentType e
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
-export type QueryResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
-> = ResolversObject<{
-  user?: Resolver<
-    Maybe<ResolversTypes['User']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryUserArgs, 'id'>
-  >;
-  machines?: Resolver<
-    Array<ResolversTypes['Machine']>,
-    ParentType,
-    ContextType
-  >;
-  machine?: Resolver<
-    Maybe<ResolversTypes['Machine']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryMachineArgs, 'id'>
-  >;
-  sensor?: Resolver<
-    Maybe<ResolversTypes['Sensor']>,
-    ParentType,
-    ContextType,
-    RequireFields<QuerySensorArgs, 'machineId' | 'id'>
-  >;
+export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
+  machines?: Resolver<Array<ResolversTypes['Machine']>, ParentType, ContextType>;
+  machine?: Resolver<Maybe<ResolversTypes['Machine']>, ParentType, ContextType, RequireFields<QueryMachineArgs, 'id'>>;
+  sensor?: Resolver<Maybe<ResolversTypes['Sensor']>, ParentType, ContextType, RequireFields<QuerySensorArgs, 'machineId' | 'id'>>;
 }>;
 
-export type SampleResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes['Sample'] = ResolversParentTypes['Sample']
-> = ResolversObject<{
+export type SampleResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Sample'] = ResolversParentTypes['Sample']> = ResolversObject<{
   timestamp?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type SampleChunkResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes['SampleChunk'] = ResolversParentTypes['SampleChunk']
-> = ResolversObject<{
+export type SampleChunkResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['SampleChunk'] = ResolversParentTypes['SampleChunk']> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   samples?: Resolver<Array<ResolversTypes['Sample']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type SensorResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes['Sensor'] = ResolversParentTypes['Sensor']
-> = ResolversObject<{
+export type SensorResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Sensor'] = ResolversParentTypes['Sensor']> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   machineId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -471,18 +399,11 @@ export type SensorResolvers<
   notificationStatus?: Resolver<Maybe<ResolversTypes['NotificationStatus']>, ParentType, ContextType>;
   threshold?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   unit?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  sampleChunks?: Resolver<
-    Array<ResolversTypes['SampleChunk']>,
-    ParentType,
-    ContextType
-  >;
+  sampleChunks?: Resolver<Array<ResolversTypes['SampleChunk']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type SensorCreationResponseResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes['SensorCreationResponse'] = ResolversParentTypes['SensorCreationResponse']
-> = ResolversObject<{
+export type SensorCreationResponseResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['SensorCreationResponse'] = ResolversParentTypes['SensorCreationResponse']> = ResolversObject<{
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -506,10 +427,7 @@ export type UserResolvers<ContextType = GraphQLContext, ParentType extends Resol
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
-export type UserUpdatedResponseResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes['UserUpdatedResponse'] = ResolversParentTypes['UserUpdatedResponse']
-> = ResolversObject<{
+export type UserUpdatedResponseResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['UserUpdatedResponse'] = ResolversParentTypes['UserUpdatedResponse']> = ResolversObject<{
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -532,6 +450,7 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   User?: UserResolvers<ContextType>;
   UserUpdatedResponse?: UserUpdatedResponseResolvers<ContextType>;
 }>;
+
 
 /**
  * @deprecated

--- a/api/functions/src/generated/graphql.ts
+++ b/api/functions/src/generated/graphql.ts
@@ -19,7 +19,7 @@ export type Machine = {
   id: Scalars['ID'];
   name: Scalars['String'];
   healthStatus?: Maybe<Status>;
-  image: Scalars['String'];
+  image?: Maybe<Scalars['String']>;
   sensors: Array<Sensor>;
 };
 
@@ -336,7 +336,7 @@ export type MachineResolvers<ContextType = GraphQLContext, ParentType extends Re
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   healthStatus?: Resolver<Maybe<ResolversTypes['Status']>, ParentType, ContextType>;
-  image?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sensors?: Resolver<Array<ResolversTypes['Sensor']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;

--- a/api/functions/src/graphql/MachineStore.ts
+++ b/api/functions/src/graphql/MachineStore.ts
@@ -46,10 +46,11 @@ const getSampleChunks = async (machineId, sensorId): Promise<any> => {
   ).docs.map(addIdToDoc);
 };
 
-const createMachine = async (machineName): Promise<Machine> => {
+const createMachine = async (machineName, imageURL): Promise<Machine> => {
   const machineDoc = await firestore.collection('machines').add({
     name: machineName,
     healthStatus: 'Nominal',
+    image: imageURL
   });
 
   return addIdToDoc(await machineDoc.get()) as Machine;
@@ -58,7 +59,8 @@ const createMachine = async (machineName): Promise<Machine> => {
 const updateMachine = async (
   machineId,
   name: string | null | undefined,
-  healthStatus: string | null | undefined
+  healthStatus: string | null | undefined,
+  imageURL: string | null | undefined
 ): Promise<Machine> => {
   const machineDoc = await firestore.doc(`machines/${machineId}`);
 

--- a/api/functions/src/graphql/resolvers/mutation.ts
+++ b/api/functions/src/graphql/resolvers/mutation.ts
@@ -13,7 +13,8 @@ export const mutationResolvers: MutationResolvers = {
     const machine = await MachineStore.updateMachine(
       args.id,
       args.input?.name,
-      args.input?.healthStatus
+      args.input?.healthStatus,
+      args.input?.image
     );
     
     const resp: any = {
@@ -48,7 +49,7 @@ export const mutationResolvers: MutationResolvers = {
   },
 
   createMachine: async (parent, args) => {
-    const newMachine = await MachineStore.createMachine(args.name);
+    const newMachine = await MachineStore.createMachine(args.name, args.image);
 
     const resp: any = {
       code: 'machine_create/success',

--- a/api/functions/src/graphql/schema.graphql
+++ b/api/functions/src/graphql/schema.graphql
@@ -21,6 +21,7 @@ type Machine {
   id: ID!
   name: String!
   healthStatus: Status
+  image: String!
   sensors: [Sensor!]!
 }
 
@@ -107,6 +108,7 @@ input SensorInput {
 input MachineUpdateInput {
   name: String
   healthStatus: Status
+  image: String
 }
 
 input SensorUpdateInput {
@@ -121,6 +123,6 @@ type Mutation {
   updateUser(id: ID!): MutationResponse
   updateMachine(id: ID! input: MachineUpdateInput): MachineUpdatedResponse
   updateSensor(id: ID! machineID: ID! input: SensorUpdateInput): SensorUpdatedResponse
-  createMachine(name: String!): MachineCreationResponse
+  createMachine(name: String!, image: String!): MachineCreationResponse
   createSensor(input: SensorInput): SensorCreationResponse
 }

--- a/api/functions/src/graphql/schema.graphql
+++ b/api/functions/src/graphql/schema.graphql
@@ -21,7 +21,7 @@ type Machine {
   id: ID!
   name: String!
   healthStatus: Status
-  image: String!
+  image: String
   sensors: [Sensor!]!
 }
 

--- a/app/src/common/graphql/mutations/machines.ts
+++ b/app/src/common/graphql/mutations/machines.ts
@@ -1,12 +1,13 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_MACHINE = gql`
-    mutation createMachine($name: String!) {
-        createMachine(name: $name) {
+    mutation createMachine($name: String!, $image: String!) {
+        createMachine(name: $name, image: $image) {
             machine {
                 id
                 name
                 healthStatus
+                image
             }
         }
     }
@@ -19,6 +20,7 @@ export const UPDATE_MACHINE = gql`
                 id
                 name
                 healthStatus
+                image
             }
         }
     }

--- a/app/src/common/graphql/queries/machines.ts
+++ b/app/src/common/graphql/queries/machines.ts
@@ -6,6 +6,7 @@ export const GET_MACHINES = gql`
             id
             name
             healthStatus
+            image
         }
     }
 `;
@@ -15,6 +16,7 @@ export const GET_MACHINE_BY_ID = gql`
         machine(id: $id) {
             name
             healthStatus
+            image
             sensors {
                 id
                 name

--- a/app/src/pages/Machines.tsx
+++ b/app/src/pages/Machines.tsx
@@ -53,7 +53,7 @@ const Machines: React.FC = () => {
                                         <MachineContainer
                                             name={machine.name}
                                             health={machine.healthStatus}
-                                            image={"random"}
+                                            image={machine.image || "random"} // random is a placeholder right now, as not all machiens have images
                                         />
                                     </Link>
                                 );

--- a/app/src/pages/Page.css
+++ b/app/src/pages/Page.css
@@ -48,7 +48,8 @@
 
 .ion-modal .modal-wrapper {
     height: 15%;
-    min-height: 200px;
+    min-height: 250px;
     width: 90%;
     max-width: 600px;
+    border-radius: 10px;
 }

--- a/app/src/pages/Page.css
+++ b/app/src/pages/Page.css
@@ -45,3 +45,10 @@
 .darken-on-hover:hover {
     filter: brightness(90%);
 }
+
+.ion-modal .modal-wrapper {
+    height: 15%;
+    min-height: 200px;
+    width: 90%;
+    max-width: 600px;
+}

--- a/app/src/pages/modals/AddMachineModal.tsx
+++ b/app/src/pages/modals/AddMachineModal.tsx
@@ -1,9 +1,11 @@
 import { FetchResult, MutationResult, useMutation } from "@apollo/client";
-import { IonAlert } from "@ionic/react";
+import { IonAlert, IonButton, IonModal } from "@ionic/react";
 import React, { useState } from "react";
 import { CREATE_MACHINE } from "../../common/graphql/mutations/machines";
 import { GET_MACHINES } from "../../common/graphql/queries/machines";
 import { createMachine } from "../../types/createMachine";
+import { v4 as uuid } from "uuid";
+import { firebaseApp } from "../../services/firebase";
 
 interface ModalProps {
     open: boolean;
@@ -11,51 +13,102 @@ interface ModalProps {
     onCompleted?: (res: FetchResult<any, Record<string, any>, Record<string, any>>) => void;
 }
 
+const SUPPORTED_IMAGE_FORMATS = ["jpg", "jpeg", "png"];
+
 export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onCompleted }) => {
+    const [image, setImage] = useState<File>();
+    const [machineName, setMachineName] = useState("");
     const [createMachineMutation] = useMutation<createMachine>(CREATE_MACHINE, {
         refetchQueries: [{ query: GET_MACHINES }],
     });
 
-    const handleAddMachine = async (alertData) => {
-        const machineName = alertData["machineName"]?.trim();
-
-        if (!machineName) {
-            return;
-        }
-
-        const result = await createMachineMutation({
-            variables: {
-                name: alertData["machineName"],
-            },
-        });
-
-        if (onCompleted) {
-            onCompleted(result);
+    const imageUploadHandler = (event) => {
+        const imageFile = event.target.files[0];
+        if (imageFile) {
+            setImage(imageFile);
         }
     };
 
+    const uploadImageToCloudStorage = async (image: File) => {
+        const fileExtension = image?.name.split(".").pop();
+        if (!fileExtension || !SUPPORTED_IMAGE_FORMATS.includes(fileExtension)) {
+            throw new Error(
+                `file extension <${fileExtension}> does not match the supported formats: ${SUPPORTED_IMAGE_FORMATS}`,
+            );
+        }
+        const key = `images/${uuid()}.${fileExtension}`;
+        const imageRef = firebaseApp.storage().ref(key);
+        await imageRef.put(image);
+        return key;
+    };
+
+    const getDownloadURl = async (key: string) => {
+        return await firebaseApp.storage().ref(key).getDownloadURL();
+    };
+
+    const handleAddMachine = async () => {
+        if (!machineName) {
+            return;
+        }
+        // Use the default image if the user has not uploaded anything
+        let key = "images/defaultImage.jpg";
+
+        if (image) {
+            key = await uploadImageToCloudStorage(image);
+        }
+        getDownloadURl(key).then(async (url) => {
+            const result = await createMachineMutation({
+                variables: {
+                    name: machineName,
+                    image: url,
+                },
+            });
+            if (onCompleted) {
+                onCompleted(result);
+            }
+        });
+    };
+
     return (
-        <IonAlert
-            isOpen={open}
-            onDidDismiss={() => setOpen(false)}
-            header={"Add a machine"}
-            inputs={[
-                {
-                    name: "machineName",
-                    type: "text",
-                    placeholder: "E.g. Machine #4",
-                },
-            ]}
-            buttons={[
-                {
-                    text: "Cancel",
-                    role: "cancel",
-                },
-                {
-                    text: "Add",
-                    handler: handleAddMachine,
-                },
-            ]}
-        />
+        // <IonAlert
+        //     isOpen={open}
+        //     onDidDismiss={() => setOpen(false)}
+        //     header={"Add a machine"}
+        //     inputs={[
+        //         {
+        //             name: "machineName",
+        //             type: "text",
+        //             placeholder: "E.g. Machine #4",
+        //         },
+        //     ]}
+        //     buttons={[
+        //         {
+        //             text: "Cancel",
+        //             role: "cancel",
+        //         },
+        //         {
+        //             text: "Add",
+        //             handler: handleAddMachine,
+        //         },
+        //     ]}
+        // />
+        <IonModal isOpen={open} onDidDismiss={() => setOpen(false)}>
+            <p>Add a New Machine</p>
+            <label>
+                Name:
+                <input
+                    name="machineName"
+                    type="text"
+                    placeholder="E.g. Machine #4"
+                    onChange={(e) => setMachineName(e.target.value)}
+                />
+            </label>
+            <label>
+                Image:
+                <input name="myFile" type="file" onChange={imageUploadHandler} accept="image/*" />
+            </label>
+            <IonButton onClick={() => setOpen(false)}>Cancel</IonButton>
+            <IonButton onClick={() => handleAddMachine()}>Add</IonButton>
+        </IonModal>
     );
 };

--- a/app/src/pages/modals/AddMachineModal.tsx
+++ b/app/src/pages/modals/AddMachineModal.tsx
@@ -1,5 +1,6 @@
 import { FetchResult, MutationResult, useMutation } from "@apollo/client";
-import { IonAlert, IonButton, IonModal } from "@ionic/react";
+import { IonButton, IonModal } from "@ionic/react";
+import "../Page.css";
 import React, { useState } from "react";
 import { CREATE_MACHINE } from "../../common/graphql/mutations/machines";
 import { GET_MACHINES } from "../../common/graphql/queries/machines";
@@ -77,23 +78,29 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
     };
 
     return (
-        <IonModal isOpen={open} onDidDismiss={() => setOpen(false)}>
-            <p>Add a New Machine</p>
-            <label>
-                Name:
-                <input
-                    name="machineName"
-                    type="text"
-                    placeholder="E.g. Machine #4"
-                    onChange={(e) => setMachineName(e.target.value)}
-                />
-            </label>
-            <label>
-                Image:
-                <input name="myFile" type="file" onChange={imageUploadHandler} accept="image/*" />
-            </label>
-            <IonButton onClick={() => setOpen(false)}>Cancel</IonButton>
-            <IonButton onClick={() => handleAddMachine()}>Add</IonButton>
+        <IonModal isOpen={open} onDidDismiss={() => setOpen(false)} cssClass="ion-modal">
+            <div className="flex flex-col">
+                <div className="flex flex-col items-center justify-items-center space-y-6">
+                    <p className="text-3xl">Add a New Machine</p>
+                    <label className="flex space-x-3">
+                        <p>Name:</p>
+                        <input
+                            name="machineName"
+                            type="text"
+                            placeholder="E.g. Machine #4"
+                            onChange={(e) => setMachineName(e.target.value)}
+                        />
+                    </label>
+                    <label className="flex space-x-3">
+                        <p>Image:</p>
+                        <input name="myFile" type="file" onChange={imageUploadHandler} accept="image/*" />
+                    </label>
+                </div>
+                <div className="flex flex-row-reverse pr-8 pt-2">
+                    <IonButton onClick={() => handleAddMachine()}>Add</IonButton>
+                    <IonButton onClick={() => setOpen(false)}>Cancel</IonButton>
+                </div>
+            </div>
         </IonModal>
     );
 };

--- a/app/src/pages/modals/AddMachineModal.tsx
+++ b/app/src/pages/modals/AddMachineModal.tsx
@@ -1,5 +1,5 @@
 import { FetchResult, MutationResult, useMutation } from "@apollo/client";
-import { IonButton, IonModal } from "@ionic/react";
+import { IonAlert, IonButton, IonModal } from "@ionic/react";
 import "../Page.css";
 import React, { useState } from "react";
 import { CREATE_MACHINE } from "../../common/graphql/mutations/machines";
@@ -19,6 +19,7 @@ const SUPPORTED_IMAGE_FORMATS = ["jpg", "jpeg", "png"];
 export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onCompleted }) => {
     const [image, setImage] = useState<File>();
     const [machineName, setMachineName] = useState("");
+    const [error, setError] = useState(false);
     const [createMachineMutation] = useMutation<createMachine>(CREATE_MACHINE, {
         refetchQueries: [{ query: GET_MACHINES }],
     });
@@ -52,6 +53,7 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
 
     const handleAddMachine = async () => {
         if (!machineName) {
+            setError(true);
             return;
         }
         // Use the default image if the user has not uploaded anything
@@ -110,6 +112,13 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
                     </IonButton>
                 </div>
             </div>
+            <IonAlert
+                isOpen={error}
+                onDidDismiss={() => setError(false)}
+                header={"Alert"}
+                message={"You must provide a name for the machine"}
+                buttons={["OK"]}
+            />
         </IonModal>
     );
 };

--- a/app/src/pages/modals/AddMachineModal.tsx
+++ b/app/src/pages/modals/AddMachineModal.tsx
@@ -80,25 +80,34 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
     return (
         <IonModal isOpen={open} onDidDismiss={() => setOpen(false)} cssClass="ion-modal">
             <div className="flex flex-col">
-                <div className="flex flex-col items-center justify-items-center space-y-6">
-                    <p className="text-3xl">Add a New Machine</p>
-                    <label className="flex space-x-3">
+                <div className="flex flex-col items-center space-y-6">
+                    <p className="text-3xl pt-2">Add a New Machine</p>
+                    <label className="flex space-x-3 items-center justify-items-start">
                         <p>Name:</p>
                         <input
                             name="machineName"
                             type="text"
                             placeholder="E.g. Machine #4"
                             onChange={(e) => setMachineName(e.target.value)}
+                            className="rounded border-2 p-2"
                         />
                     </label>
-                    <label className="flex space-x-3">
+                    <label className="flex space-x-3 items-center">
                         <p>Image:</p>
-                        <input name="myFile" type="file" onChange={imageUploadHandler} accept="image/*" />
+                        <input
+                            name="myFile"
+                            type="file"
+                            onChange={imageUploadHandler}
+                            accept="image/*"
+                            className="rounded border-2 p-2"
+                        />
                     </label>
                 </div>
                 <div className="flex flex-row-reverse pr-8 pt-2">
                     <IonButton onClick={() => handleAddMachine()}>Add</IonButton>
-                    <IonButton onClick={() => setOpen(false)}>Cancel</IonButton>
+                    <IonButton color="medium" onClick={() => setOpen(false)}>
+                        Cancel
+                    </IonButton>
                 </div>
             </div>
         </IonModal>

--- a/app/src/pages/modals/AddMachineModal.tsx
+++ b/app/src/pages/modals/AddMachineModal.tsx
@@ -30,12 +30,15 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
     };
 
     const uploadImageToCloudStorage = async (image: File) => {
+        // Get the file extension for compatibility
         const fileExtension = image?.name.split(".").pop();
         if (!fileExtension || !SUPPORTED_IMAGE_FORMATS.includes(fileExtension)) {
             throw new Error(
                 `file extension <${fileExtension}> does not match the supported formats: ${SUPPORTED_IMAGE_FORMATS}`,
             );
         }
+
+        // Store the image in the database
         const key = `images/${uuid()}.${fileExtension}`;
         const imageRef = firebaseApp.storage().ref(key);
         await imageRef.put(image);
@@ -53,9 +56,12 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
         // Use the default image if the user has not uploaded anything
         let key = "images/defaultImage.jpg";
 
+        // Store the image (if user provided one)
         if (image) {
             key = await uploadImageToCloudStorage(image);
         }
+
+        // Retrieve the image URL and create new machine with it
         getDownloadURl(key).then(async (url) => {
             const result = await createMachineMutation({
                 variables: {
@@ -71,28 +77,6 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
     };
 
     return (
-        // <IonAlert
-        //     isOpen={open}
-        //     onDidDismiss={() => setOpen(false)}
-        //     header={"Add a machine"}
-        //     inputs={[
-        //         {
-        //             name: "machineName",
-        //             type: "text",
-        //             placeholder: "E.g. Machine #4",
-        //         },
-        //     ]}
-        //     buttons={[
-        //         {
-        //             text: "Cancel",
-        //             role: "cancel",
-        //         },
-        //         {
-        //             text: "Add",
-        //             handler: handleAddMachine,
-        //         },
-        //     ]}
-        // />
         <IonModal isOpen={open} onDidDismiss={() => setOpen(false)}>
             <p>Add a New Machine</p>
             <label>

--- a/app/src/pages/modals/AddMachineModal.tsx
+++ b/app/src/pages/modals/AddMachineModal.tsx
@@ -66,6 +66,7 @@ export const AddMachineModal: React.FC<ModalProps> = ({ open, setOpen, onComplet
             if (onCompleted) {
                 onCompleted(result);
             }
+            setOpen(false);
         });
     };
 

--- a/app/src/services/firebase/index.ts
+++ b/app/src/services/firebase/index.ts
@@ -1,5 +1,6 @@
 import * as firebase from "firebase/app";
 import "firebase/auth";
+import "firebase/storage";
 
 const firebaseConfig = {
     apiKey: "AIzaSyAiu7ApIWegQ2RmKwr5augncAzvpIjEGXE",

--- a/app/src/types/createMachine.ts
+++ b/app/src/types/createMachine.ts
@@ -14,6 +14,7 @@ export interface createMachine_createMachine_machine {
   id: string;
   name: string;
   healthStatus: Status | null;
+  image: string;
 }
 
 export interface createMachine_createMachine {
@@ -27,4 +28,5 @@ export interface createMachine {
 
 export interface createMachineVariables {
   name: string;
+  image: string;
 }

--- a/app/src/types/createMachine.ts
+++ b/app/src/types/createMachine.ts
@@ -14,7 +14,7 @@ export interface createMachine_createMachine_machine {
   id: string;
   name: string;
   healthStatus: Status | null;
-  image: string;
+  image: string | null;
 }
 
 export interface createMachine_createMachine {

--- a/app/src/types/getMachineById.ts
+++ b/app/src/types/getMachineById.ts
@@ -34,6 +34,7 @@ export interface getMachineById_machine {
   __typename: "Machine";
   name: string;
   healthStatus: Status | null;
+  image: string;
   sensors: getMachineById_machine_sensors[];
 }
 

--- a/app/src/types/getMachineById.ts
+++ b/app/src/types/getMachineById.ts
@@ -34,7 +34,7 @@ export interface getMachineById_machine {
   __typename: "Machine";
   name: string;
   healthStatus: Status | null;
-  image: string;
+  image: string | null;
   sensors: getMachineById_machine_sensors[];
 }
 

--- a/app/src/types/getMachines.ts
+++ b/app/src/types/getMachines.ts
@@ -14,7 +14,7 @@ export interface getMachines_machines {
   id: string;
   name: string;
   healthStatus: Status | null;
-  image: string;
+  image: string | null;
 }
 
 export interface getMachines {

--- a/app/src/types/getMachines.ts
+++ b/app/src/types/getMachines.ts
@@ -14,6 +14,7 @@ export interface getMachines_machines {
   id: string;
   name: string;
   healthStatus: Status | null;
+  image: string;
 }
 
 export interface getMachines {

--- a/app/src/types/globalTypes.ts
+++ b/app/src/types/globalTypes.ts
@@ -22,6 +22,7 @@ export enum Status {
 export interface MachineUpdateInput {
   name?: string | null;
   healthStatus?: Status | null;
+  image?: string | null;
 }
 
 export interface SensorInput {

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -46,6 +46,7 @@ export type Machine = {
     id: Scalars["ID"];
     name: Scalars["String"];
     healthStatus?: Maybe<Status>;
+    image: Scalars["String"];
     sensors: Array<Sensor>;
 };
 
@@ -111,6 +112,7 @@ export type MutationUpdateSensorArgs = {
 
 export type MutationCreateMachineArgs = {
     name: Scalars["String"];
+    image: Scalars["String"];
 };
 
 export type MutationCreateSensorArgs = {
@@ -126,6 +128,7 @@ export type MutationResponse = {
 export type MachineUpdateInput = {
     name?: Maybe<Scalars["String"]>;
     healthStatus?: Maybe<Status>;
+    image?: Maybe<Scalars["String"]>;
 };
 
 export type MachineUpdatedResponse = MutationResponse & {

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -46,7 +46,7 @@ export type Machine = {
     id: Scalars["ID"];
     name: Scalars["String"];
     healthStatus?: Maybe<Status>;
-    image: Scalars["String"];
+    image?: Maybe<Scalars["String"]>;
     sensors: Array<Sensor>;
 };
 

--- a/app/src/types/updateMachine.ts
+++ b/app/src/types/updateMachine.ts
@@ -14,6 +14,7 @@ export interface updateMachine_updateMachine_machine {
   id: string;
   name: string;
   healthStatus: Status | null;
+  image: string;
 }
 
 export interface updateMachine_updateMachine {

--- a/app/src/types/updateMachine.ts
+++ b/app/src/types/updateMachine.ts
@@ -14,7 +14,7 @@ export interface updateMachine_updateMachine_machine {
   id: string;
   name: string;
   healthStatus: Status | null;
-  image: string;
+  image: string | null;
 }
 
 export interface updateMachine_updateMachine {


### PR DESCRIPTION
## GitHub Issue Solved:

closes #62 

## Current behaviour

Machines images are selected from a small pool randomly

## Changed behaviour

Machine images can now be set for each machine. the images are stored in the firebase cloud storage, and the URL for these images are stored within the machine schemas in the firestore database. A new modal has been created to fit the image uploading

## PR checklist

Remember to check the following

 - [x] Tag specific people to review your PR
 - [ ] Update the ReadMe with any new run instructions
 - [x] Closes the associated issue (if applicable)
 - [ ] Updated kanban board

## Notes

N/A

### Demo

![image](https://user-images.githubusercontent.com/38555691/94779636-c6c38180-0423-11eb-84e0-141338c728fa.png)

### Run instructions
Just run `npm start` in the root directory like usual
