### PR TITLE
Iot ingestor/handle multiple sensors

### DIFF
--- a/api/functions/src/ingestor/submitFiles.ts
+++ b/api/functions/src/ingestor/submitFiles.ts
@@ -2,7 +2,7 @@
 require('dotenv').config();
 import fs from 'fs';
 import fetch, { RequestInit } from 'node-fetch';
-import os from 'os';
+import * as os from 'os';
 
 const DELAY_IN_MILLISECONDS = 1000;
 
@@ -19,9 +19,9 @@ const currentDir = __dirname;
 let directory = '';
 const isWindows = os.platform() === 'win32';
 if (isWindows) {
-  directory = currentDir + '\\..\\..\\inputData\\';
+  directory = currentDir + '\\..\\..\\..\\inputData\\';
 } else {
-  directory = currentDir + '/../../inputData/';
+  directory = currentDir + '/../../../inputData/';
 }
 
 const filePaths = findDataFileNamesInDir(directory);

--- a/api/functions/src/ingestor/thresholdDetection.ts
+++ b/api/functions/src/ingestor/thresholdDetection.ts
@@ -53,7 +53,7 @@ export async function pushState(
     });
 }
 
-export function doThresholdDetection(
+export async function doThresholdDetection(
   rmsValue: number,
   machineId: string,
   sensorId: string
@@ -81,10 +81,8 @@ export function doThresholdDetection(
 
       if (state.badReadingCounter >= 10) {
         // TODO: Update this section to set the corresponding sensor notificationStatus value to unacknowledged
-        if (!state.notified) {
-          updateMachineNotificationStatus(machineId);
-        }
-        sendNotification(state.thresholdValue, rmsValue, machineId, sensorId);
+        await updateMachineNotificationStatus(machineId);
+        notifyUsers(state.thresholdValue, rmsValue, machineId, sensorId);
       }
     } else {
       state.goodReadingCounter++;
@@ -128,23 +126,4 @@ function calculateThreshold() {
   const standardDeviation = Math.sqrt(squaredDifferencesMean);
 
   return rmsMean + 6 * standardDeviation;
-}
-
-function sendNotification(
-  thresholdValue: number,
-  rmsValue: number,
-  machineId: string,
-  sensorId: string
-) {
-  /* TODO add checker for notification frequency (or do it somewhere else) 
-       Currently this is done using a state.notified flag which ensures the email is only sent once,
-       (for demo purposes)
-    */
-  // Update the db to reflect this issue.
-  if (!state.notified) {
-    // Hardcoded values for the sensor and machine ID were used, these will be changed
-    // The values used for the IDs are not reflective of realistic IDs within the system.
-    notifyUsers(thresholdValue, rmsValue, machineId, sensorId);
-    state.notified = true;
-  }
 }

--- a/api/functions/src/ingestor/thresholdDetection.ts
+++ b/api/functions/src/ingestor/thresholdDetection.ts
@@ -1,5 +1,4 @@
 import { notifyUsers } from '../notifications/notificationService';
-import { updateSensorNotificationStatus } from './storeTofirebase';
 import { updateMachineNotificationStatus } from './storeTofirebase';
 import { firebaseApp } from '../firebase';
 

--- a/api/functions/src/notifications/notificationService.ts
+++ b/api/functions/src/notifications/notificationService.ts
@@ -9,12 +9,16 @@ if (process.env.NODE_ENV == 'development') {
   sgMail.setApiKey(process.env.SENDGRID_API_KEY!);
 }
 
+// Use this to instantly receive an email
+// notifyUsers(1, 1.1, 'KJPGkuNVivC5scheOIz0', '2hKLutzjE0ufQen8xTm3'); 
+
 export async function notifyUsers(
   threshold,
   recordedValue,
   sensorId,
   machineId
 ) {
+  console.log('notifyUsers function is being called');
   const sensorRef = firestore
     .collection(`machines/${machineId}/sensors`)
     .doc(sensorId);
@@ -29,9 +33,9 @@ export async function notifyUsers(
     const subject = 'Error detected with Machine ' + machine!.name;
     const html =
       'Sensor ' +
-      sensorId +
+      sensor.data()!.name +
       ' on machine ' +
-      machineId +
+      machine!.name +
       ' has crossed its threshold.<br/>' +
       'Threshold: ' +
       threshold +

--- a/api/functions/src/notifications/notificationService.ts
+++ b/api/functions/src/notifications/notificationService.ts
@@ -24,35 +24,37 @@ export async function notifyUsers(
   const machineDoc = await machineRef.get();
   const machine = machineDoc.data();
 
-  const senderEmail = 'industry4errornotification@gmail.com';
-  const subject = 'Error detected with Machine ' + machine!.name;
-  const html =
-    'Sensor ' +
-    sensorId +
-    ' on machine ' +
-    machineId +
-    ' has crossed its threshold.<br/>' +
-    'Threshold: ' +
-    threshold +
-    '<br/>' +
-    'Recorded Value: ' +
-    recordedValue +
-    '<br/>' +
-    // This will be updated to link the the application when we have it deployed
-    '<a>Click here to view the error</a>';
+  if (machine!.notificationStatus == 'Unacknowledged') {
+    const senderEmail = 'industry4errornotification@gmail.com';
+    const subject = 'Error detected with Machine ' + machine!.name;
+    const html =
+      'Sensor ' +
+      sensorId +
+      ' on machine ' +
+      machineId +
+      ' has crossed its threshold.<br/>' +
+      'Threshold: ' +
+      threshold +
+      '<br/>' +
+      'Recorded Value: ' +
+      recordedValue +
+      '<br/>' +
+      // This will be updated to link the the application when we have it deployed
+      '<a>Click here to view the error</a>';
 
-  if (machine != undefined && machine != null) {
-    machine.subscribers.forEach((email) => {
-      const receiverEmail = email;
-      const msg = {
-        to: receiverEmail,
-        from: senderEmail,
-        subject: subject,
-        html: html,
-      };
+    if (machine != undefined && machine != null) {
+      machine.subscribers.forEach((email) => {
+        const receiverEmail = email;
+        const msg = {
+          to: receiverEmail,
+          from: senderEmail,
+          subject: subject,
+          html: html,
+        };
 
-      // sgMail.send(msg);
-    });
+        sgMail.send(msg);
+      });
+    }
   }
 }
 
@@ -100,7 +102,7 @@ export async function updateUsers() {
         html: emailMsg,
       };
 
-      // sgMail.send(msg);
+      sgMail.send(msg);
     }
   }
 }

--- a/api/functions/src/notifications/notificationService.ts
+++ b/api/functions/src/notifications/notificationService.ts
@@ -18,7 +18,6 @@ export async function notifyUsers(
   sensorId,
   machineId
 ) {
-  console.log('notifyUsers function is being called');
   const sensorRef = firestore
     .collection(`machines/${machineId}/sensors`)
     .doc(sensorId);


### PR DESCRIPTION
## GitHub Issue Solved:

closes #43 
Requires completion of #77, then with changes made accordingly

## Current behaviour

Currently, the state of the sensors is not saved in the cloud function ingestor. This means that state data does not persist in the ingestor as global vars any more (as the old ingestor did). There is a need to keep track of the states of separate sensors, so that once 10 consecutive readings from the same sensor meet the threshold, notification(s) can be made accordingly.

## Changed behaviour

Ingestor is in the form of a Firebase Function (covered by #59)
Ingestor can take the machine ID and sensor ID as input alongside data (at this stage this is done by changing `machineId` and `sensorId` in the submitFiles.ts file)
State data and RMS data is stored under the correct sensor in Firestore

## PR checklist

Remember to check the following

 - [x] Tag specific people to review your PR
 - [ ] Update the ReadMe with any new run instructions
 - [x] Closes the associated issue (if applicable)
 - [ ] Updated kanban board

## Notes

The original PR also included the uploading of a .csv file to firestore, which has been left out so far. A separate PR or further work & details in this one may be needed.
<!--You may add screenshots or other information if you think it's relevant-->

### Demo

<!--If applicable, give a demo to help people understand the PR change-->

### Run instructions

The following run instructions have been copied from Marc's PR #67 as it is essentially the same.

To run, do what you'd normally do with npm i. Before you run, make a copy of api/functions/env.sample and call it .env. Make sure the .env file links to a correct GOOGLE_APPLICATION_CREDENTIALS.json file. This file is not present on the repo so make sure to get the credentials for your project.

Run npm start from either the root of the project or api/functions - your choice. Once that's going, open up a new cmd prompt / terminal and run submitFiles.ts with ts-node e.g. `ts-node src/ingestor/submitFiles.ts` if I'm inside api/functions. Note that you MUST run it this way (i.e. from api/functions, not from the /ingestor)

This should just start populating sensor 'KJPGkuNVivC5scheOIz0' of machine '2hKLutzjE0ufQen8xTm3' with data. You should see both the submitFiles.ts script and the Ingestor FB Function log stuff in the console.

Log into firebase in your browser and view the cloud firestore data. Navigate to the above sensor, and you should see the `state` field containing various data such as `goodReadingCounter` and `badReadingCounter`. To check if it's working upon starting, the `processedFileCount` will always tick up, so just check that this is being updated as the local program runs on your pc. This number may be in the hundreds or thousands already, this is expected as a sensor's history is never 'reset' through the program.
