### PR TITLE
Button spamming bug

### DIFF
--- a/app/src/pages/Sensors.tsx
+++ b/app/src/pages/Sensors.tsx
@@ -36,7 +36,7 @@ import { SensorModal } from "./modals/SensorModal";
 
 const Sensors: React.FC = () => {
     const [addMachineOpen, setAddMachineOpen] = useState<boolean>(false);
-
+    const [disabled, setDisabled] = useState(false);
     const { id } = useParams<{ id: string }>();
     const machine_data = useQuery<getMachineById>(GET_MACHINE_BY_ID, {
         variables: { id: id },
@@ -80,6 +80,12 @@ const Sensors: React.FC = () => {
     }
 
     const handleSubscribe = async () => {
+        // Used to stop button spamming
+        if (disabled) {
+            return;
+        }
+        setDisabled(true);
+
         if (!userID) {
             const newUser = await createUserMutation({
                 variables: {
@@ -96,6 +102,8 @@ const Sensors: React.FC = () => {
                     userID: userID,
                     machineID: id,
                 },
+            }).then(() => {
+                setDisabled(false);
             });
 
             setSubscribed(false);
@@ -106,6 +114,8 @@ const Sensors: React.FC = () => {
                     userID: userID,
                     machineID: id,
                 },
+            }).then(() => {
+                setDisabled(false);
             });
 
             setSubscribed(true);

--- a/app/src/pages/modals/MachineModal.tsx
+++ b/app/src/pages/modals/MachineModal.tsx
@@ -40,6 +40,7 @@ export const MachineModal: React.FC<ModalProps> = ({
     showAll,
 }) => {
     const [image, setImage] = useState<File>();
+    const [disabled, setDisabled] = useState(false);
     const [machineName, setMachineName] = useState("");
     const [addError, setAddError] = useState(false);
     const [updateError, setUpdateError] = useState(false);
@@ -94,6 +95,11 @@ export const MachineModal: React.FC<ModalProps> = ({
             setAddError(true);
             return;
         }
+
+        if (disabled) {
+            return;
+        }
+        setDisabled(true);
         // Use the default image if the user has not uploaded anything
         let key = "images/defaultImage.jpg";
 
@@ -120,7 +126,10 @@ export const MachineModal: React.FC<ModalProps> = ({
             }
             const result2 = await subscribeMutation({
                 variables: { userID: userID, machineID: result.data?.createMachine?.machine?.id },
+            }).then(() => {
+                setDisabled(false);
             });
+
             if (onCompleted) {
                 onCompleted(result);
             }

--- a/app/src/pages/modals/SensorModal.tsx
+++ b/app/src/pages/modals/SensorModal.tsx
@@ -17,6 +17,8 @@ interface ModalProps {
 }
 
 export const SensorModal: React.FC<ModalProps> = ({ open, setOpen, machineId, onCompleted, action, name, id }) => {
+    const [disabled, setDisabled] = useState(false);
+
     const [createSensorMutation] = useMutation<createSensor>(CREATE_SENSOR, {
         refetchQueries: [{ query: GET_MACHINE_BY_ID, variables: { id: machineId } }],
     });
@@ -32,6 +34,10 @@ export const SensorModal: React.FC<ModalProps> = ({ open, setOpen, machineId, on
             return;
         }
 
+        if (disabled) {
+            return;
+        }
+        setDisabled(true);
         const result = await createSensorMutation({
             variables: {
                 input: {
@@ -39,11 +45,9 @@ export const SensorModal: React.FC<ModalProps> = ({ open, setOpen, machineId, on
                     machineID: machineId,
                 },
             },
+        }).then(() => {
+            setDisabled(false);
         });
-
-        if (onCompleted) {
-            onCompleted(result);
-        }
     };
 
     const handleUpdateSensor = async (alertData) => {


### PR DESCRIPTION
## GitHub Issue Solved:

closes #75 

## Current behaviour

Submitting multiple times will cause multiple entries in the database to be created when only 1 should happen

## Changed behaviour

No longer creates multiple entries when a button (like add machines, sensors, subscribed) is spammedf

## PR checklist

Remember to check the following

 - [x] Tag specific people to review your PR
 - [ ] Update the ReadMe with any new run instructions
 - [x] Closes the associated issue (if applicable)
 - [ ] Updated kanban board

## Notes

This PR mainly handles the subscriber button, add machine button and add sensor button. Other ones have not been looked at, but should be if there are any

### Demo

n/a

### Run instructions

just the normal `npm start` at root
