### PR TITLE
Machine status fix

### DIFF
--- a/app/src/common/graphql/queries/machines.ts
+++ b/app/src/common/graphql/queries/machines.ts
@@ -9,6 +9,11 @@ export const GET_MACHINES = gql`
             notificationStatus
             healthStatus
             image
+            sensors {
+                id
+                name
+                healthStatus
+            }
         }
     }
 `;

--- a/app/src/types/getMachines.ts
+++ b/app/src/types/getMachines.ts
@@ -9,6 +9,13 @@ import { NotificationStatus, Status } from "./globalTypes";
 // GraphQL query operation: getMachines
 // ====================================================
 
+export interface getMachines_machines_sensors {
+  __typename: "Sensor";
+  id: string;
+  name: string;
+  healthStatus: Status | null;
+}
+
 export interface getMachines_machines {
   __typename: "Machine";
   id: string;
@@ -17,6 +24,7 @@ export interface getMachines_machines {
   notificationStatus: NotificationStatus | null;
   healthStatus: Status | null;
   image: string | null;
+  sensors: getMachines_machines_sensors[];
 }
 
 export interface getMachines {


### PR DESCRIPTION
## GitHub Issue Solved:

closes #85 

## Current behaviour
Machine status (and colour) does not update based on the sensor's status

## Changed behaviour
Machine status and color now updates based on the sensors' status.

## PR checklist

Remember to check the following

 - [x] Tag specific people to review your PR
 - [ ] Update the ReadMe with any new run instructions
 - [x] Closes the associated issue (if applicable)
 - [ ] Updated kanban board

## Notes

Essentially, we could have sensors which were critical (red) inside one machine, and yet the machine's color stayed at either green or yellow. I've found that we've never actually updated a machine's health status based on the sensor's health status, and thus this has now been changed to reflect that. 

Also, currently we need to reflect the page to requery it.

### Demo

N/A

### Run instructions

Just the normal `npm start` in the root directory. To actually test it, I would recommend going to the firestore storage and change a few of the sensor colors (recommend machine 3 with the ID : `e91T0tfxhQDFjUJnUJNw`). Play around with it and see if it changes colors properly.
